### PR TITLE
Fix provider to read app configuration

### DIFF
--- a/src/Lumen/ServiceProvider.php
+++ b/src/Lumen/ServiceProvider.php
@@ -10,6 +10,8 @@ class ServiceProvider extends IlluminateServiceProvider
 {
     public function register()
     {
+        $this->app->configure('json-api');
+
         $this->mergeConfigFrom(__DIR__ . '/../../config/json-api.php', 'json-api');
 
         $this->app->bind(MediaTypeGuard::class, function ($app) {


### PR DESCRIPTION
It seems that without calling `$this->app->configure('json-api');` first the provider does not pick up the configuration values from the application config file.