### PR TITLE
add 'wantsJsonApi' macro to Response class

### DIFF
--- a/src/Lumen/ServiceProvider.php
+++ b/src/Lumen/ServiceProvider.php
@@ -5,9 +5,19 @@ namespace RealPage\JsonApi\Lumen;
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
 use RealPage\JsonApi\MediaTypeGuard;
 use RealPage\JsonApi\EncoderService;
+use Illuminate\Support\Str;
+use Illuminate\Http\Request;
 
 class ServiceProvider extends IlluminateServiceProvider
 {
+    public function boot()
+    {
+        Request::macro('wantsJsonApi', function () {
+            $acceptable = $this->getAcceptableContentTypes();
+            return isset($acceptable[0]) && Str::contains($acceptable[0], ['application/vnd.api+json']);
+        });
+    }
+
     public function register()
     {
         $this->app->configure('json-api');


### PR DESCRIPTION
Behaves identically to the builtin `wantsJson` method, but checks for `application/vnd.api+json` instead. Usage: `$request->wantsJsonApi()`