### PR TITLE
Allow to configure Accept header treatment

### DIFF
--- a/config/json-api.php
+++ b/config/json-api.php
@@ -16,4 +16,17 @@ return [
     // 'encoder-options' => [
     //     'options' => JSON_PRETTY_PRINT,
     // ],
+
+    // accept-header-policy configuration defines how to handle Accept header in requests.
+    //
+    // If accept-header-policy is set to 'default' or 'require', api will response with
+    // 406 (Not Acceptable) if request has an Accept header, which does not match
+    // configured media-type.
+    //
+    // If accept-header-policy is set to 'require', requests without an Accept header
+    // will be responded by a 406 (Not Acceptable).
+    //
+    // If accept-header-policy is set to 'ignore', api will response all requests with a
+    // json api document regardless of Accept header.
+    'accept-header-policy' => 'default',
 ];

--- a/src/Lumen/ServiceProvider.php
+++ b/src/Lumen/ServiceProvider.php
@@ -15,7 +15,7 @@ class ServiceProvider extends IlluminateServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/../../config/json-api.php', 'json-api');
 
         $this->app->bind(MediaTypeGuard::class, function ($app) {
-            return new MediaTypeGuard(config('json-api.media-type'));
+            return new MediaTypeGuard(config('json-api.media-type'), config('json-api.accept-header-policy');
         });
 
         $this->app->bind(EncoderService::class, function ($app) {

--- a/src/MediaTypeGuard.php
+++ b/src/MediaTypeGuard.php
@@ -8,14 +8,20 @@ class MediaTypeGuard
 {
     protected $contentType;
 
-    public function __construct(string $contentType)
+    public function __construct(string $contentType, string $acceptHeaderPolicy)
     {
         $this->contentType = $contentType;
+        $this->acceptHeaderPolicy = $acceptHeaderPolicy;
     }
 
     public function getContentType(): string
     {
         return $this->contentType;
+    }
+
+    public function getAcceptHeaderPolicy(): string
+    {
+        return $this->acceptHeaderPolicy;
     }
 
     public function validateExistingContentType(Request $request): bool
@@ -43,10 +49,19 @@ class MediaTypeGuard
 
     public function hasCorrectlySetAcceptHeader(Request $request): bool
     {
-        $accept = $request->header('Accept');
-        if ('*/*' !== $accept) {
-            return substr_count($accept, $this->getContentType()) > substr_count($accept, $this->getContentType() . ';');
+        if ($this->acceptHeaderPolicy === 'ignore') {
+            return true;
         }
-        return true;
+
+        $accept = $request->header('Accept');
+        if (empty($accept)) {
+            return $this->acceptHeaderPolicy !== 'require';
+        }
+
+        if ('*/*' === $accept) {
+            return true;
+        }
+
+        return substr_count($accept, $this->getContentType()) > substr_count($accept, $this->getContentType() . ';');
     }
 }


### PR DESCRIPTION
feat: support configuration of Accept header treatment
    
This commit changes default behavior. Set accept-header-policy to 'require' to have same handling of Accept header as before.

PR includes #18. If you like to merge them separately feel free to cherry-pick.

Closes #4
