### PR TITLE
Fix: throws if GET request has query params but not a Content-Type header

### DIFF
--- a/src/MediaTypeGuard.php
+++ b/src/MediaTypeGuard.php
@@ -23,9 +23,10 @@ class MediaTypeGuard
         return str_is($this->getContentType(), $request->header('Accept')) || str_is('', $request->header('Accept'));
     }
 
-    public function clientRequestHasJsonApiData(Request $request)
+    public function clientRequestMustHaveContentTypeHeader(Request $request)
     {
-        return !empty($request->all());
+        $method = $request->method();
+        return $method === 'POST' || $method === 'PATCH';
     }
 
     public function contentTypeIsValid(string $contentType): bool
@@ -35,7 +36,7 @@ class MediaTypeGuard
 
     public function hasCorrectHeadersForData(Request $request): bool
     {
-        if ($this->clientRequestHasJsonApiData($request)) {
+        if ($this->clientRequestMustHaveContentTypeHeader($request)) {
             return $request->hasHeader('Content-Type') && $this->contentTypeIsValid($request->header('Content-Type'));
         }
         return true;

--- a/src/MediaTypeGuard.php
+++ b/src/MediaTypeGuard.php
@@ -36,7 +36,7 @@ class MediaTypeGuard
     public function hasCorrectHeadersForData(Request $request): bool
     {
         if ($this->clientRequestHasJsonApiData($request)) {
-            return $this->contentTypeIsValid($request->header('Content-Type'));
+            return $request->hasHeader('Content-Type') && $this->contentTypeIsValid($request->header('Content-Type'));
         }
         return true;
     }

--- a/tests/MediaTypeGuardTest.php
+++ b/tests/MediaTypeGuardTest.php
@@ -36,15 +36,18 @@ class MediaTypeGuardTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->guard->validateExistingContentType($validContentTypeRequest));
     }
 
-    public function testRecognizesIfJsonDataIsPresent()
+    public function testRecognizesIfRequestMustHaveContentTypeHeader()
     {
-        $emptyRequest = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods(['all'])->getMock();
-        $fullRequest  = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods(['all'])->getMock();
-        $emptyRequest->expects($this->any())->method('all')->willReturn([]);
-        $fullRequest->expects($this->any())->method('all')->willReturn(['data' => 'exists']);
+        $getRequest = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods(['method'])->getMock();
+        $postRequest  = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods(['method'])->getMock();
+        $patchRequest  = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods(['method'])->getMock();
+        $getRequest->expects($this->any())->method('method')->willReturn('GET');
+        $postRequest->expects($this->any())->method('method')->willReturn('POST');
+        $patchRequest->expects($this->any())->method('method')->willReturn('POST');
 
-        $this->assertFalse($this->guard->clientRequestHasJsonApiData($emptyRequest));
-        $this->assertTrue($this->guard->clientRequestHasJsonApiData($fullRequest));
+        $this->assertFalse($this->guard->clientRequestMustHaveContentTypeHeader($getRequest));
+        $this->assertTrue($this->guard->clientRequestMustHaveContentTypeHeader($postRequest));
+        $this->assertTrue($this->guard->clientRequestMustHaveContentTypeHeader($patchRequest));
     }
 
     public function testContentTypeIsValid()
@@ -62,49 +65,49 @@ class MediaTypeGuardTest extends \PHPUnit\Framework\TestCase
     {
         $validContentType    = 'application/vnd.api+json';
         $invalidContentType  = 'application/json';
-        $emptyValidRequest   = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
-            'all',
+        $getValidRequest   = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
             'header',
+            'method',
         ])->getMock();
-        $emptyInvalidRequest = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
-            'all',
+        $getInvalidRequest = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
             'header',
+            'method',
         ])->getMock();
-        $emptyWithoutRequest  = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
-            'all',
+        $getWithoutRequest  = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
             'header',
+            'method',
         ])->getMock();
-        $fullValidRequest    = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
-            'all',
+        $postValidRequest    = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
             'header',
+            'method',
         ])->getMock();
-        $fullInvalidRequest  = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
-            'all',
+        $postInvalidRequest  = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
             'header',
+            'method',
         ])->getMock();
-        $fullWithoutRequest  = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
-            'all',
+        $postWithoutRequest  = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
             'header',
+            'method',
         ])->getMock();
-        $emptyValidRequest->expects($this->any())->method('all')->willReturn([]);
-        $emptyValidRequest->expects($this->any())->method('header')->willReturn($validContentType);
-        $emptyInvalidRequest->expects($this->any())->method('all')->willReturn([]);
-        $emptyInvalidRequest->expects($this->any())->method('header')->willReturn($invalidContentType);
-        $emptyWithoutRequest->expects($this->any())->method('all')->willReturn([]);
-        $emptyWithoutRequest->expects($this->any())->method('header')->willReturn(null);
-        $fullValidRequest->expects($this->any())->method('all')->willReturn(['data' => 'exists']);
-        $fullValidRequest->expects($this->any())->method('header')->willReturn($validContentType);
-        $fullInvalidRequest->expects($this->any())->method('all')->willReturn(['data' => 'exists']);
-        $fullInvalidRequest->expects($this->any())->method('header')->willReturn($invalidContentType);
-        $fullWithoutRequest->expects($this->any())->method('all')->willReturn(['data' => 'exists']);
-        $fullWithoutRequest->expects($this->any())->method('header')->willReturn(null);
+        $getValidRequest->expects($this->any())->method('method')->willReturn('GET');
+        $getValidRequest->expects($this->any())->method('header')->willReturn($validContentType);
+        $getInvalidRequest->expects($this->any())->method('method')->willReturn('GET');
+        $getInvalidRequest->expects($this->any())->method('header')->willReturn($invalidContentType);
+        $getWithoutRequest->expects($this->any())->method('method')->willReturn('GET');
+        $getWithoutRequest->expects($this->any())->method('header')->willReturn(null);
+        $postValidRequest->expects($this->any())->method('method')->willReturn('POST');
+        $postValidRequest->expects($this->any())->method('header')->willReturn($validContentType);
+        $postInvalidRequest->expects($this->any())->method('method')->willReturn('POST');
+        $postInvalidRequest->expects($this->any())->method('header')->willReturn($invalidContentType);
+        $postWithoutRequest->expects($this->any())->method('method')->willReturn('POST');
+        $postWithoutRequest->expects($this->any())->method('header')->willReturn(null);
 
-        $this->assertTrue($this->guard->hasCorrectHeadersForData($emptyValidRequest));
-        $this->assertTrue($this->guard->hasCorrectHeadersForData($emptyInvalidRequest));
-        $this->assertTrue($this->guard->hasCorrectHeadersForData($emptyWithoutRequest));
-        $this->assertTrue($this->guard->hasCorrectHeadersForData($fullValidRequest));
-        $this->assertFalse($this->guard->hasCorrectHeadersForData($fullInvalidRequest));
-        $this->assertFalse($this->guard->hasCorrectHeadersForData($fullWithoutRequest));
+        $this->assertTrue($this->guard->hasCorrectHeadersForData($getValidRequest));
+        $this->assertTrue($this->guard->hasCorrectHeadersForData($getInvalidRequest));
+        $this->assertTrue($this->guard->hasCorrectHeadersForData($getWithoutRequest));
+        $this->assertTrue($this->guard->hasCorrectHeadersForData($postValidRequest));
+        $this->assertFalse($this->guard->hasCorrectHeadersForData($postInvalidRequest));
+        $this->assertFalse($this->guard->hasCorrectHeadersForData($postWithoutRequest));
     }
 
     public function testDeterminesCorrectlySetAcceptHeader()

--- a/tests/MediaTypeGuardTest.php
+++ b/tests/MediaTypeGuardTest.php
@@ -70,6 +70,10 @@ class MediaTypeGuardTest extends \PHPUnit\Framework\TestCase
             'all',
             'header',
         ])->getMock();
+        $emptyWithoutRequest  = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
+            'all',
+            'header',
+        ])->getMock();
         $fullValidRequest    = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
             'all',
             'header',
@@ -78,19 +82,29 @@ class MediaTypeGuardTest extends \PHPUnit\Framework\TestCase
             'all',
             'header',
         ])->getMock();
+        $fullWithoutRequest  = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods([
+            'all',
+            'header',
+        ])->getMock();
         $emptyValidRequest->expects($this->any())->method('all')->willReturn([]);
         $emptyValidRequest->expects($this->any())->method('header')->willReturn($validContentType);
         $emptyInvalidRequest->expects($this->any())->method('all')->willReturn([]);
         $emptyInvalidRequest->expects($this->any())->method('header')->willReturn($invalidContentType);
+        $emptyWithoutRequest->expects($this->any())->method('all')->willReturn([]);
+        $emptyWithoutRequest->expects($this->any())->method('header')->willReturn(null);
         $fullValidRequest->expects($this->any())->method('all')->willReturn(['data' => 'exists']);
         $fullValidRequest->expects($this->any())->method('header')->willReturn($validContentType);
         $fullInvalidRequest->expects($this->any())->method('all')->willReturn(['data' => 'exists']);
         $fullInvalidRequest->expects($this->any())->method('header')->willReturn($invalidContentType);
+        $fullWithoutRequest->expects($this->any())->method('all')->willReturn(['data' => 'exists']);
+        $fullWithoutRequest->expects($this->any())->method('header')->willReturn(null);
 
         $this->assertTrue($this->guard->hasCorrectHeadersForData($emptyValidRequest));
         $this->assertTrue($this->guard->hasCorrectHeadersForData($emptyInvalidRequest));
+        $this->assertTrue($this->guard->hasCorrectHeadersForData($emptyWithoutRequest));
         $this->assertTrue($this->guard->hasCorrectHeadersForData($fullValidRequest));
         $this->assertFalse($this->guard->hasCorrectHeadersForData($fullInvalidRequest));
+        $this->assertFalse($this->guard->hasCorrectHeadersForData($fullWithoutRequest));
     }
 
     public function testDeterminesCorrectlySetAcceptHeader()


### PR DESCRIPTION
Fixes two bugs:

1. Throws if a Content-Type header is necessary but not provided since `contentTypeIsValid()` requires first parameter to be a `string` and not `null`.
2. `$request->all()` returns query params on `GET` request. Therefore json-api-for-lumen has enforced a Content-Type header which is not necessary.